### PR TITLE
removed additional introductory lab

### DIFF
--- a/typical_schedule.md
+++ b/typical_schedule.md
@@ -26,11 +26,10 @@
 |Ch 25 | - | - | 9 |
 | ACM 95 ab | - | 12 | 12 |
 |Bi 122 | 9 | - | - |
-| Additional intro lab requirement | - | 6 | - | 
 |Menu course  | - | - | 9 |
-| HSS | 9 | 9 | - |
+| HSS | 9 | 18 | - |
 |Physical education | - | 3 | 3 |
-|**Total** | 45 | 39 | 42 |
+|**Total** | 45 | 42 | 42 |
 
 
 ## Third year
@@ -54,11 +53,11 @@
 | ------------- |-------------:| -----:| -----:|
 | Bi/BE 24 | 6 | - | - |
 | BE/APh 161 | - | 12 | - |
-|BE/CS/CNS/Bi 191 a | - | 9 | - | 
+|BE/CS/CNS/Bi 191 a | - | 9 | - |
 |BE 150 | - | - | 9 |
 |BE/Bi 106 | - | 9 | - |
 | BE 98 | 9 | - | 9 |
 | Bi/CNS/NB 154| 9 | - | - |
 | ChE 130 | - | - | 9 |
-| HSS | 18 | 9 | 18 |
-|**Total** | 42 | 39 | 45 |
+| HSS | 18 | 9 | 9 |
+|**Total** | 42 | 39 | 36 |


### PR DESCRIPTION
I'm pretty sure that advanced labs, even those that are requirements for the major, count as an additional introductory lab. So by taking Bi 1x or BE 196a or BE 189, one satisfies that requirement (however I'm only like 70% sure of this). I just redistributed the HSS units, but I think it might make more sense to move some of the BE classes from year 4 winter. That would also add a BE class to sophomore year, which is something we had talked about.